### PR TITLE
Compare rather than set so we can view the raw XML view

### DIFF
--- a/fields/field.entry_relationship.php
+++ b/fields/field.entry_relationship.php
@@ -640,7 +640,7 @@
 			}
 			
 			// devkit will load
-			$devkit = isset($_GET['debug']) && (empty($_GET['debug']) || $_GET['debug'] = 'xml');
+			$devkit = isset($_GET['debug']) && (empty($_GET['debug']) || $_GET['debug'] == 'xml');
 			
 			// selected items
 			$entries = static::getEntries($data);


### PR DESCRIPTION
`?debug=raw` should show the debugdevkit plain XML view but instead it shows the styled XML view because we are setting the debug field to `xml` whenever it has a value