### PR TITLE
Fix entry relationship save when no enties linked

### DIFF
--- a/content/content.save.php
+++ b/content/content.save.php
@@ -136,7 +136,7 @@
 			}
 			
 			// set new data
-			$entryData[$parentFieldId]['entries'] = implode(',', $entriesId);
+			$entryData[$parentFieldId]['entries'] = empty($entriesId) ? null : implode(',', $entriesId);
 			
 			// check if data are valid
 			$resMessage = null;


### PR DESCRIPTION
Empty string was saved when no entries instead of null, which is what we want.