### PR TITLE
Fix erronous code for php 7.2

### DIFF
--- a/fields/field.entry_relationship.php
+++ b/fields/field.entry_relationship.php
@@ -1020,7 +1020,7 @@
 					continue;
 				}
 				// sectionName.fieldName or sectionName.*
-				$parts = array_map(trim, explode('.', $value, 2));
+				$parts = array_map('trim', explode('.', $value, 2));
 				// first time seeing this section
 				if (!isset($elements[$parts[0]])) {
 					$elements[$parts[0]] = array();

--- a/lib/class.field.relationship.php
+++ b/lib/class.field.relationship.php
@@ -46,7 +46,7 @@ class FieldRelationship extends Field
 
     public function getArray($name)
     {
-        return array_filter(array_map(trim, explode(self::SEPARATOR, trim($this->get($name)))));
+        return array_filter(array_map('trim', explode(self::SEPARATOR, trim($this->get($name)))));
     }
 
     /**
@@ -60,7 +60,7 @@ class FieldRelationship extends Field
 
     public static function getEntries(array $data)
     {
-        return array_map(array('General', 'intval'), array_filter(array_map(trim, explode(self::SEPARATOR, $data['entries']))));
+        return array_map(array('General', 'intval'), array_filter(array_map('trim', explode(self::SEPARATOR, $data['entries']))));
     }
 
     /**


### PR DESCRIPTION
In php 7.2, use of inexistant constant gives an error instead of possibly being transformed to a string.